### PR TITLE
Restructure Tasks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/include/rio/core_count.hpp
 add_custom_target(GenerateCoreCountHeader ALL DEPENDS ${CMAKE_SOURCE_DIR}/include/rio/core_count.hpp)
 
 # Define the library, link dependencies, and include directories
-add_library(rio STATIC src/worker.cpp src/scheduler.cpp)
+add_library(rio STATIC src/worker.cpp src/scheduler.cpp src/task.cpp)
 target_include_directories(rio PUBLIC include ${FOLLY_INCLUDE_DIR})
 target_link_libraries(rio PRIVATE ${FOLLY_LIBRARY})
 add_dependencies(rio GenerateCoreCountHeader)
@@ -40,7 +40,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(googletest)
 
 # Test executable
-add_executable(rio_tests test/executor_test.cpp test/worker_test.cpp test/scheduler_test.cpp)
+add_executable(rio_tests test/executor_test.cpp test/worker_test.cpp test/scheduler_test.cpp test/task_test.cpp)
 target_link_libraries(rio_tests PRIVATE rio gtest_main)
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     target_link_libraries(rio_tests PRIVATE c++abi)

--- a/include/rio/scheduler.hpp
+++ b/include/rio/scheduler.hpp
@@ -19,6 +19,7 @@
 #include <future>
 #include <semaphore>
 #include <utility>
+#include "rio/task.hpp"
 #include "rio/worker.hpp"
 
 namespace rio {
@@ -52,28 +53,11 @@ class scheduler {
       typename... A,
       typename R = std::invoke_result_t<std::decay_t<F>, std::decay_t<A>...>>
   std::future<R> await(F&& function, A&&... arguments) {
-    auto promise = new std::promise<R>();
-    std::future<R> future = promise->get_future();
-
-    auto task = [promise, function = std::forward<F>(function),
-                 ... arguments = std::forward<A>(arguments)]() mutable {
-      try {
-        // Invoke the function and handle the return type appropriately
-        if constexpr (std::is_same_v<R, void>) {
-          std::invoke(function, arguments...);
-          promise->set_value();
-        } else {
-          promise->set_value(std::invoke(function, arguments...));
-        }
-      } catch (...) {
-        promise->set_exception(std::current_exception());
-      }
-
-      delete promise;
-    };
+    auto [future, task] = rio::task::build(std::forward<F>(function),
+                                           std::forward<A>(arguments)...);
 
     schedule(std::move(task));
-    return future;
+    return std::move(future);
   }
 };
 

--- a/include/rio/scheduler.hpp
+++ b/include/rio/scheduler.hpp
@@ -53,8 +53,8 @@ class scheduler {
       typename... A,
       typename R = std::invoke_result_t<std::decay_t<F>, std::decay_t<A>...>>
   std::future<R> await(F&& function, A&&... arguments) {
-    auto [future, task] = rio::task::build(std::forward<F>(function),
-                                           std::forward<A>(arguments)...);
+    auto [future, task] = rio::task::make(std::forward<F>(function),
+                                          std::forward<A>(arguments)...);
 
     schedule(std::move(task));
     return std::move(future);

--- a/include/rio/task.hpp
+++ b/include/rio/task.hpp
@@ -81,7 +81,7 @@ class task {
   void operator()();
 
   /// Returns whether or not the callable has been executed already.
-  bool executed() const;
+  bool is_executed() const;
 };
 
 /// Represents a task and its associated future. The future holds the result

--- a/include/rio/task.hpp
+++ b/include/rio/task.hpp
@@ -60,7 +60,7 @@ class task {
     auto propagater = [promise, function = std::forward<F>(function),
                        ... arguments = std::forward<A>(arguments)]() mutable {
       try {
-        // Invoke the function and handle the return type appropriately
+        // Invoke the callable and handle the return type appropriately
         if constexpr (std::is_same_v<R, void>) {
           std::invoke(function, arguments...);
           promise->set_value();
@@ -77,11 +77,14 @@ class task {
     return {std::move(future), std::move(task(propagater))};
   }
 
-  /// Executes the encapsulated function if it has not been executed already.
+  /// Executes the encapsulated callable if it has not been executed already.
   void operator()();
+
+  /// Returns whether or not the callable has been executed already.
+  bool executed() const;
 };
 
-/// Encapsulates a task and its associated future. The future holds the result
+/// Represents a task and its associated future. The future holds the result
 /// of the task, which may be obtained asynchronously.
 template <typename R>
 struct task_closure {

--- a/include/rio/task.hpp
+++ b/include/rio/task.hpp
@@ -53,7 +53,7 @@ class task {
       typename F,
       typename... A,
       typename R = std::invoke_result_t<std::decay_t<F>, std::decay_t<A>...>>
-  static task_closure<R> build(F&& function, A&&... arguments) {
+  static task_closure<R> make(F&& function, A&&... arguments) {
     auto promise = new std::promise<R>();
     std::future<R> future = promise->get_future();
 

--- a/include/rio/task.hpp
+++ b/include/rio/task.hpp
@@ -1,0 +1,91 @@
+// MIT License
+// Copyright (c) 2024 Ayush Gundawar <ayushgundawar (at) gmail (dot) com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <future>
+
+namespace rio {
+/// Forward declaration of the task closure struct to be used in task::build().
+template <typename R>
+struct task_closure;
+
+/// Manages the execution of a single callable function asynchronously, ensuring
+/// it only runs once.
+class task {
+ private:
+  std::function<void()> propagator;
+  std::atomic<bool> has_executed;
+
+ private:
+  /// Receives a propagator function built by task::build() and stores it as a
+  /// member for later execution.
+  task(std::function<void()>);
+
+ public:
+  task(const task&) = delete;
+  task& operator=(const task&) = delete;
+
+  /// Move constructor that transfers ownership of the task. Primarily used when
+  /// transferring the task into a task closure.
+  task(task&&);
+
+  /// Move assignment operator that transfers ownership of the task. Primarily
+  /// used when transferring the task into a task closure.
+  task& operator=(task&&);
+
+  /// Constructs a task from a callable and its arguments, and returns a
+  /// task closure containing the future result and the task. Allows for
+  /// asynchronous execution and result retrieval through std::future.
+  template <
+      typename F,
+      typename... A,
+      typename R = std::invoke_result_t<std::decay_t<F>, std::decay_t<A>...>>
+  static task_closure<R> build(F&& function, A&&... arguments) {
+    auto promise = new std::promise<R>();
+    std::future<R> future = promise->get_future();
+
+    auto propagater = [promise, function = std::forward<F>(function),
+                       ... arguments = std::forward<A>(arguments)]() mutable {
+      try {
+        // Invoke the function and handle the return type appropriately
+        if constexpr (std::is_same_v<R, void>) {
+          std::invoke(function, arguments...);
+          promise->set_value();
+        } else {
+          promise->set_value(std::invoke(function, arguments...));
+        }
+      } catch (...) {
+        promise->set_exception(std::current_exception());
+      }
+
+      delete promise;
+    };
+
+    return {std::move(future), std::move(task(propagater))};
+  }
+
+  /// Executes the encapsulated function if it has not been executed already.
+  void operator()();
+};
+
+/// Encapsulates a task and its associated future. The future holds the result
+/// of the task, which may be obtained asynchronously.
+template <typename R>
+struct task_closure {
+  std::future<R> future;  // Future to hold the result after task execution.
+  rio::task task;         // Single-callable task which fills the future.
+};
+}  // namespace rio

--- a/include/rio/worker.hpp
+++ b/include/rio/worker.hpp
@@ -15,26 +15,24 @@
 
 #include <atomic>
 #include <cstddef>
-#include <functional>
 #include <semaphore>
 #include <thread>
 #include "folly/ProducerConsumerQueue.h"
+#include "rio/task.hpp"
 
 namespace rio {
 /// Represents a unique identifier for a worker.
 using worker_id = std::size_t;
-
-/// Invokable work wrapped with result propogation logic.
-using task = std::function<void()>;
 
 /// Represents a worker thread that executes tasks from a queue.
 class worker {
  private:
   folly::ProducerConsumerQueue<rio::task> tasks;
   std::binary_semaphore ready;
-  std::atomic_flag stop;
+  std::atomic<bool> stop;
   std::thread thread;
 
+ private:
   /// Processes all work in the task queue.
   void process_work();
 

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -33,3 +33,7 @@ void rio::task::operator()() {
     propagator();
   }
 }
+
+bool rio::task::executed() const {
+  return has_executed.load();
+}

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -34,6 +34,6 @@ void rio::task::operator()() {
   }
 }
 
-bool rio::task::executed() const {
+bool rio::task::is_executed() const {
   return has_executed.load();
 }

--- a/test/scheduler_test.cpp
+++ b/test/scheduler_test.cpp
@@ -1,74 +1,86 @@
-// // MIT License
-// // Copyright (c) 2024 Ayush Gundawar <ayushgundawar (at) gmail (dot) com>
-// //
-// // Permission is hereby granted, free of charge, to any person obtaining a
-// copy
-// // of this software and associated documentation files (the "Software"), to
-// deal
-// // in the Software without restriction, including without limitation the
-// rights
-// // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// // copies of the Software, and to permit persons to whom the Software is
-// // furnished to do so, subject to the following conditions:
-// //
-// // The above copyright notice and this permission notice shall be included in
-// // all copies or substantial portions of the Software.
+// MIT License
+// Copyright (c) 2024 Ayush Gundawar <ayushgundawar (at) gmail (dot) com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 
-// #include "rio/scheduler.hpp"
-// #include <gtest/gtest.h>
+#include "rio/scheduler.hpp"
+#include <gtest/gtest.h>
+#include <future>
+#include <thread>
+#include "rio/task.hpp"
 
-// TEST(fcfs_scheduler_test, in_order_scheduling) {
-//   rio::fcfs_scheduler scheduler(4);  // Create a scheduler for 4 workers
-//   rio::task task_1 = []() {};
-//   rio::task task_2 = []() {};
+class fcfs_scheduler_test : public ::testing::Test {
+ protected:
+  rio::fcfs_scheduler scheduler;
 
-//   scheduler.await(std::move(task_1));
-//   scheduler.await(std::move(task_2));
+  fcfs_scheduler_test() : scheduler(4) {}
+};
 
-//   auto scheduled_task_1 = scheduler.next();
-//   auto scheduled_task_2 = scheduler.next();
+TEST_F(fcfs_scheduler_test, SchedulerCanScheduleAndRetrieveTask) {
+  auto future = scheduler.await([]() { return 42; });
+  EXPECT_TRUE(scheduler.has_tasks());
 
-//   // Verify that tasks are retrieved in the order they were scheduled
-//   ASSERT_TRUE(scheduled_task_1.has_value());
-//   ASSERT_TRUE(scheduled_task_2.has_value());
-//   EXPECT_NE(
-//       scheduled_task_1->wid,
-//       scheduled_task_2
-//           ->wid);  // Ensure different workers are used in round-robin
-//           fashion
-// }
+  auto scheduled_task = scheduler.next();
+  scheduled_task.task();
+  EXPECT_EQ(future.get(), 42);
+}
 
-// TEST(fcfs_scheduler_test, nullopt_when_empty) {
-//   rio::fcfs_scheduler scheduler(4);
+TEST_F(fcfs_scheduler_test, SchedulerHandlesMultipleTasks) {
+  auto future1 = scheduler.await([]() { return 42; });
+  auto future2 = scheduler.await([]() { return 24; });
+  EXPECT_TRUE(scheduler.has_tasks());
 
-//   auto result = scheduler.next();
-//   ASSERT_FALSE(result.has_value());
-// }
+  auto scheduled_task1 = scheduler.next();
+  scheduled_task1.task();
+  EXPECT_EQ(future1.get(), 42);
 
-// TEST(fcfs_scheduler_test, same_wid_for_single_worker) {
-//   rio::fcfs_scheduler scheduler(1);  // Single worker for simplicity
+  auto scheduled_task2 = scheduler.next();
+  scheduled_task2.task();
+  EXPECT_EQ(future2.get(), 24);
+}
 
-//   // Define multiple tasks, but since we're only interested in wid, we don't
-//   // need them to do anything
-//   rio::task task_1 = []() {};
-//   rio::task task_2 = []() {};
-//   rio::task task_3 = []() {};
+TEST_F(fcfs_scheduler_test, SchedulerAssignsTasksToWorkerInFCFS) {
+  auto future1 = scheduler.await([]() { return 42; });
+  auto future2 = scheduler.await([]() { return 24; });
+  EXPECT_TRUE(scheduler.has_tasks());
 
-//   // Queue the tasks
-//   scheduler.await(std::move(task_1));
-//   scheduler.await(std::move(task_2));
-//   scheduler.await(std::move(task_3));
+  auto scheduled_task1 = scheduler.next();
+  EXPECT_EQ(scheduled_task1.wid, 0);
+  scheduled_task1.task();
+  EXPECT_EQ(future1.get(), 42);
 
-//   // Retrieve and execute tasks, while checking for consistent worker IDs
-//   std::optional<rio::scheduled_task> scheduled_task_1 = scheduler.next();
-//   std::optional<rio::scheduled_task> scheduled_task_2 = scheduler.next();
-//   std::optional<rio::scheduled_task> scheduled_task_3 = scheduler.next();
+  auto scheduled_task2 = scheduler.next();
+  EXPECT_EQ(scheduled_task2.wid, 1);
+  scheduled_task2.task();
+  EXPECT_EQ(future2.get(), 24);
+}
 
-//   ASSERT_TRUE(scheduled_task_1.has_value());
-//   ASSERT_TRUE(scheduled_task_2.has_value());
-//   ASSERT_TRUE(scheduled_task_3.has_value());
+TEST_F(fcfs_scheduler_test, SchedulerNextBlocksUntilTaskIsAvailable) {
+  auto future = scheduler.await([]() { return 42; });
 
-//   // Check if all tasks have the same worker id
-//   EXPECT_EQ(scheduled_task_1->wid, scheduled_task_2->wid);
-//   EXPECT_EQ(scheduled_task_2->wid, scheduled_task_3->wid);
-// }
+  std::thread t([&]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    auto scheduled_task = scheduler.next();
+    scheduled_task.task();
+  });
+
+  t.join();
+  EXPECT_EQ(future.get(), 42);
+}
+
+TEST_F(fcfs_scheduler_test, AwaitSchedulesTaskAndReturnsFuture) {
+  auto future = scheduler.await([]() { return 42; });
+  EXPECT_TRUE(scheduler.has_tasks());
+
+  auto scheduled_task = scheduler.next();
+  scheduled_task.task();
+  EXPECT_EQ(future.get(), 42);
+}

--- a/test/task_test.cpp
+++ b/test/task_test.cpp
@@ -1,0 +1,82 @@
+// MIT License
+// Copyright (c) 2024 Ayush Gundawar <ayushgundawar (at) gmail (dot) com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+#include "rio/task.hpp"
+#include <gtest/gtest.h>
+#include <future>
+
+TEST(task_test, TaskExecutesFunctionCorrectly) {
+  auto task_closure = rio::task::make([]() { return 42; });
+
+  task_closure.task();
+  EXPECT_EQ(task_closure.future.get(), 42);
+}
+
+TEST(task_test, TaskExecutesVoidFunctionCorrectly) {
+  bool executed = false;
+  auto task_closure = rio::task::make([&]() { executed = true; });
+
+  task_closure.task();
+  task_closure.future.get();  // Wait for the task to complete
+  EXPECT_TRUE(executed);
+}
+
+TEST(task_test, TaskExecutesOnlyOnce) {
+  int count = 0;
+  auto task_closure = rio::task::make([&]() { ++count; });
+
+  task_closure.task();
+  task_closure.task();  // Second execution should have no effect
+  task_closure.future.get();
+  EXPECT_EQ(count, 1);
+}
+
+TEST(task_test, TaskHandlesException) {
+  auto task_closure =
+      rio::task::make([]() { throw std::runtime_error("error"); });
+
+  task_closure.task();
+  EXPECT_THROW(task_closure.future.get(), std::runtime_error);
+}
+
+TEST(task_test, TaskMoveConstructorTransfersOwnership) {
+  auto task_closure1 = rio::task::make([]() { return 42; });
+  rio::task moved_task = std::move(task_closure1.task);
+
+  moved_task();
+  EXPECT_EQ(task_closure1.future.get(), 42);
+}
+
+TEST(task_test, TaskMoveAssignmentTransfersOwnership) {
+  auto task_closure1 = rio::task::make([]() { return 42; });
+  rio::task moved_task = std::move(task_closure1.task);
+  auto task_closure2 = rio::task::make([]() { return 24; });
+
+  task_closure2.task = std::move(moved_task);
+
+  task_closure2.task();
+  EXPECT_EQ(task_closure1.future.get(), 42);
+}
+
+TEST(task_test, TaskMoveAssignmentTransfersHasExecutedFlag) {
+  auto task_closure1 = rio::task::make([]() { return 42; });
+  rio::task moved_task = std::move(task_closure1.task);
+  auto task_closure2 = rio::task::make([]() { return 24; });
+
+  task_closure2.task = std::move(moved_task);
+  task_closure2.task();
+
+  // Check if the task has been executed once
+  EXPECT_TRUE(task_closure2.task.is_executed());
+  EXPECT_EQ(task_closure1.future.get(), 42);
+}

--- a/test/worker_test.cpp
+++ b/test/worker_test.cpp
@@ -13,32 +13,59 @@
 
 #include "rio/worker.hpp"
 #include <gtest/gtest.h>
+#include <atomic>
+#include <future>
+#include "rio/task.hpp"
 
 class worker_test : public ::testing::Test {
  protected:
-  rio::worker test_worker;
+  rio::worker worker;
 };
 
-TEST_F(worker_test, task_execution) {
-  std::atomic<bool> task_completed{false};
+TEST_F(worker_test, WorkerExecutesSingleTask) {
+  auto task_closure = rio::task::make([]() { return 42; });
 
-  test_worker.assign([&]() { task_completed.store(true); });
-
-  // Allow some time for the worker to pick up and execute the task
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-  EXPECT_TRUE(task_completed.load());
+  worker.assign(std::move(task_closure.task));
+  EXPECT_EQ(task_closure.future.get(), 42);
 }
 
-TEST_F(worker_test, multiple_tasks) {
-  std::atomic<int> counter{0};
+TEST_F(worker_test, WorkerExecutesMultipleTasks) {
+  auto task_closure1 = rio::task::make([]() { return 42; });
+  auto task_closure2 = rio::task::make([]() { return 24; });
 
-  for (int i = 0; i < 10; ++i) {
-    test_worker.assign([&]() { counter.fetch_add(1); });
-  }
+  worker.assign(std::move(task_closure1.task));
+  worker.assign(std::move(task_closure2.task));
 
-  // Allow some time for the worker to pick up and execute all tasks
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  EXPECT_EQ(task_closure1.future.get(), 42);
+  EXPECT_EQ(task_closure2.future.get(), 24);
+}
 
-  EXPECT_EQ(counter.load(), 10);
+TEST_F(worker_test, WorkerHandlesVoidTasks) {
+  std::atomic<bool> executed = false;
+  auto task_closure = rio::task::make([&executed]() { executed = true; });
+
+  worker.assign(std::move(task_closure.task));
+  task_closure.future.get();  // Wait for the task to complete
+  EXPECT_TRUE(executed.load());
+}
+
+TEST_F(worker_test, WorkerStopsGracefully) {
+  std::atomic<bool> executed = false;
+  auto task_closure = rio::task::make([&executed]() { executed = true; });
+
+  worker.assign(std::move(task_closure.task));
+  task_closure.future.get();  // Wait for the task to complete
+  EXPECT_TRUE(executed.load());
+}
+
+TEST_F(worker_test, WorkerStopsWhenDestructed) {
+  {
+    rio::worker temporary_worker;
+    auto task_closure = rio::task::make([]() { return 42; });
+
+    temporary_worker.assign(std::move(task_closure.task));
+    EXPECT_EQ(task_closure.future.get(), 42);
+  }  // temporary_worker is destructed here
+
+  // No assertion here, just ensuring no crashes or hangs
 }


### PR DESCRIPTION
Turns rio::task into a single callable executable wrapper class. Rewrites unit tests to use new interface. Simplifies scheduler `await`.